### PR TITLE
Remove redundant transport start calls

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -288,7 +288,6 @@ export class ObsidianServer {
       });
 
       await this.server.connect(transport);
-      await transport.start();
 
       transport.onerror = (error) => {
         console.error("Transport error:", error);
@@ -346,7 +345,6 @@ export class ObsidianServer {
 
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    await transport.start();
     console.error("Obsidian MCP Server running on stdio");
     this.activeTransport = transport;
   }


### PR DESCRIPTION
## Summary
- remove redundant `transport.start()` calls in the stdio and HTTP server startup paths so the MCP server relies on `server.connect`

## Testing
- bun run build
- bun build/main.js /workspace/obsidian-mcp-baies/tmpvault

------
https://chatgpt.com/codex/tasks/task_e_68daa38dcda08331bdf9f25c4b22ef79