### PR TITLE
Normalize HTTP request paths for MCP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -296,7 +296,12 @@ export class ObsidianServer {
       const server = http.createServer(async (req, res) => {
         const url = req.url ? new URL(req.url, `http://${req.headers.host ?? "localhost"}`) : null;
 
-        if (!url || url.pathname !== config.path) {
+        const normalizePath = (inputPath: string) => {
+          const stripped = inputPath.replace(/\/+$/, "");
+          return stripped === "" ? "/" : stripped;
+        };
+
+        if (!url || normalizePath(url.pathname) !== normalizePath(config.path)) {
           res.writeHead(404).end("Not Found");
           return;
         }


### PR DESCRIPTION
## Summary
- accept both bare and trailing-slash variants of the configured HTTP path
- reduce spurious 404 responses during the MCP handshake when clients normalize paths differently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce6a61e208331be442b4446e8be08